### PR TITLE
fix: improve a11y to text alternative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13449,18 +13449,6 @@
         "resolve": "^1.20.0"
       },
       "dependencies": {
-        "postcss-selector-parser": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-          "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
-          "dev": true,
-          "requires": {
-            "cssesc": "^3.0.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1",
-            "util-deprecate": "^1.0.2"
-          }
-        },
         "postcss-value-parser": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",

--- a/src/components/Bar/index.jsx
+++ b/src/components/Bar/index.jsx
@@ -13,7 +13,7 @@ const Bar = ({ date, countries, country, setCountry }) => (
     </select>
     <hr className="flex-1 hidden lg:block border-gray-200" />
     <span className="ml-4 uppercase text-3xl lg:text-xs mt-4 lg:mt-0">
-      Last Updated at: <b>{date}</b>
+      Last Updated at: <strong>{date}</strong>
     </span>
   </div>
 );

--- a/src/components/StatsCard/index.jsx
+++ b/src/components/StatsCard/index.jsx
@@ -27,7 +27,7 @@ const StatsCard = ({ data, subdata, type }) => (
         <span className="text-3xl lg:text-sm">{typeConfig['title'][type]}</span>
         <img
           src={typeConfig['icons'][type]}
-          alt="Card icon"
+          alt=""
           className="invert ml-auto h-12 lg:h-7"
         />
       </div>
@@ -49,7 +49,7 @@ const StatsCard = ({ data, subdata, type }) => (
               ) : (
                 <img
                   src={upArrow}
-                  alt="Up arrow"
+                  alt="Increased to"
                   className="invert h-6 lg:h-4 mb-0.5 mr-1"
                 />
               )}

--- a/src/components/StatsCard/index.jsx
+++ b/src/components/StatsCard/index.jsx
@@ -41,7 +41,7 @@ const StatsCard = ({ data, subdata, type }) => (
         </span>
         <span className="flex items-center mx-auto text-3xl lg:text-sm justify-center flex-1">
           {subdata === '' ? (
-            'N/A'
+            (data === '' ? '' : 'N/A')
           ) : (
             <>
               {type === 'country' ? (

--- a/src/components/StatsCard/index.jsx
+++ b/src/components/StatsCard/index.jsx
@@ -49,7 +49,7 @@ const StatsCard = ({ data, subdata, type }) => (
               ) : (
                 <img
                   src={upArrow}
-                  alt="Increased to"
+                  alt="Increased by"
                   className="invert h-6 lg:h-4 mb-0.5 mr-1"
                 />
               )}

--- a/src/components/VaccineCard/index.jsx
+++ b/src/components/VaccineCard/index.jsx
@@ -28,13 +28,13 @@ const VaccineCard = ({ data, subdata, type }) => (
         <div className="flex flex-row ml-auto">
           <img
             src={typeConfig['icons'][type]}
-            alt="Vaccine icon"
+            alt=""
             className="invert  h-12 lg:h-7"
           />
           {type === 'double' && (
             <img
               src={typeConfig['icons'][type]}
-              alt="Vaccine icon"
+              alt=""
               className="invert  h-12 lg:h-7"
             />
           )}
@@ -51,7 +51,7 @@ const VaccineCard = ({ data, subdata, type }) => (
               {type === 'total' ? (
                 <img
                   src={upArrow}
-                  alt="Up arrow"
+                  alt="Increased to"
                   className="invert h-6 lg:h-4 mb-0.5 mr-1"
                 />
               ) : (

--- a/src/components/VaccineCard/index.jsx
+++ b/src/components/VaccineCard/index.jsx
@@ -51,7 +51,7 @@ const VaccineCard = ({ data, subdata, type }) => (
               {type === 'total' ? (
                 <img
                   src={upArrow}
-                  alt="Increased to"
+                  alt="Increased by"
                   className="invert h-6 lg:h-4 mb-0.5 mr-1"
                 />
               ) : (

--- a/src/components/VaccineCard/index.jsx
+++ b/src/components/VaccineCard/index.jsx
@@ -45,9 +45,8 @@ const VaccineCard = ({ data, subdata, type }) => (
           {data === '' ? 'N/A' : Number(data).toLocaleString()}
         </span>
         <span className="flex items-center mx-auto text-3xl lg:text-sm">
-          {subdata === '' ? (
-            ''
-          ) : (
+          {subdata === '' ? (data === '' ? '' : 'N/A')
+           : (
             <>
               {type === 'total' ? (
                 <img

--- a/src/pages/Dashboard/index.jsx
+++ b/src/pages/Dashboard/index.jsx
@@ -44,8 +44,8 @@ const Dashboard = () => {
   } = finalData;
 
   return (
-    <div className="lg:container px-8 xl:items-center mx-auto pb-8 mt-8 xl:mt-20 font-poppins tracking-widest flex justify-center flex-col xl:flex-row text-white">
-      <div>
+    <div className="lg:container px-8 mx-auto pb-8 mt-8 xl:mt-20 font-poppins tracking-widest flex flex-col xl:flex-row text-white">
+      <div className="mt-20">
         <img
           src={hero}
           className="pr-8 hidden xl:block "

--- a/src/pages/Dashboard/index.jsx
+++ b/src/pages/Dashboard/index.jsx
@@ -10,7 +10,8 @@ import Bar from 'components/Bar';
 import { logo, hero } from 'assets/images';
 
 const Dashboard = () => {
-  const [country, setCountry] = useState('Brazil');
+  const storedCountry = localStorage.getItem('country') ?? 'Brazil';
+  const [country, setCountry] = useState(storedCountry);
 
   const { data, isLoading, isError } = useQuery(['data'], () => getData());
 
@@ -43,6 +44,11 @@ const Dashboard = () => {
     people_fully_vaccinated_per_hundred,
   } = finalData;
 
+  const handleCountryChange = (country) => {
+    setCountry(country);
+    localStorage.setItem('country', country);
+  };
+
   return (
     <div className="lg:container px-8 mx-auto pb-8 mt-8 xl:mt-20 font-poppins tracking-widest flex flex-col xl:flex-row text-white">
       <div className="mt-20">
@@ -68,7 +74,7 @@ const Dashboard = () => {
         <Bar
           date={last_updated_date}
           country={country}
-          setCountry={setCountry}
+          setCountry={handleCountryChange}
           countries={countries}
         />
 

--- a/src/pages/Dashboard/index.jsx
+++ b/src/pages/Dashboard/index.jsx
@@ -60,7 +60,7 @@ const Dashboard = () => {
         <img
           src={logo}
           className="px-8 block xl:hidden"
-          alt="Covid Stats logo"
+          alt="Covid Stats"
         />
       </div>
 
@@ -68,7 +68,7 @@ const Dashboard = () => {
         <img
           src={logo}
           className="p-8 hidden xl:block"
-          alt="Covid Stats logo"
+          alt="Covid Stats"
         />
 
         <Bar


### PR DESCRIPTION
# Propose of this PR

This PR proposes a better description of images, icons usually don't be described.

## Resume of changes

* delete unused text alternative;
* improve text alternative of the logo "Covid Stats";
* add a better description of icon "Up arrow".
* remove de `<b>`and use the correct element `<strong>`.


According to [WCAG guideline 1.1.1](https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html), we must describe images that are contextual.

Images that are only decorative can be used according to the quote below:

> "If non-text content is pure decoration, is used only for visual formatting or is not presented to users, then it is implemented in a way that it can be ignored by assistive technology."